### PR TITLE
Added code that allows user to add an image to button background

### DIFF
--- a/EJSelectMenuExample/Assets.xcassets/Contents.json
+++ b/EJSelectMenuExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/EJSelectMenuExample/Base.lproj/Main.storyboard
+++ b/EJSelectMenuExample/Base.lproj/Main.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -21,15 +20,17 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I1w-Xb-xRn">
                                 <rect key="frame" x="20" y="36" width="560" height="21"/>
+                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="2hl-rL-kxh">
-                                <rect key="frame" x="150" y="147" width="300" height="305"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" distribution="equalSpacing" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="2hl-rL-kxh">
+                                <rect key="frame" x="150" y="147" width="300" height="360"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6O-yk-zWT">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" red="0.34509803919999998" green="0.45098039220000002" blue="0.62745098040000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="300" id="BAC-TY-OmN"/>
@@ -41,8 +42,23 @@
                                             <action selector="popUp3Buttons:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IZc-hi-qb7"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aeC-sp-U6a">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ev-bA-TBM">
                                         <rect key="frame" x="0.0" y="55" width="300" height="30"/>
+                                        <animations/>
+                                        <color key="backgroundColor" red="0.61441332101821899" green="0.38870418071746826" blue="0.39470201730728149" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="300" id="IQR-Ji-uwL"/>
+                                            <constraint firstAttribute="width" secondItem="7Ev-bA-TBM" secondAttribute="height" multiplier="10:1" id="SRm-UM-CD9"/>
+                                        </constraints>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <state key="normal" title="3 buttons Fade In Animation (Image)"/>
+                                        <connections>
+                                            <action selector="popUp3ButtonsWithImages:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gQR-Ur-xR7"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aeC-sp-U6a">
+                                        <rect key="frame" x="0.0" y="110" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="300" id="2Af-n6-gkM"/>
@@ -55,7 +71,8 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SGq-aZ-eRa">
-                                        <rect key="frame" x="0.0" y="110" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="165" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" red="0.039215686270000001" green="0.30588235289999999" blue="0.76078431369999999" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="SGq-aZ-eRa" secondAttribute="height" multiplier="10:1" id="key-MF-iZ6"/>
@@ -68,7 +85,8 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eRJ-3B-AVI">
-                                        <rect key="frame" x="0.0" y="165" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="220" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" red="0.49504756969362568" green="0.64982947136233282" blue="0.90088848040000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="eRJ-3B-AVI" secondAttribute="height" multiplier="10:1" id="BQz-vf-p0u"/>
@@ -81,7 +99,8 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y7M-dr-ZPI">
-                                        <rect key="frame" x="0.0" y="220" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="275" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" red="0.38498871486270925" green="0.62476789959191925" blue="0.61045878725986658" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="300" id="fUe-iN-Hsn"/>
@@ -94,7 +113,8 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cbI-Yn-48h">
-                                        <rect key="frame" x="0.0" y="275" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="330" width="300" height="30"/>
+                                        <animations/>
                                         <color key="backgroundColor" red="0.29719435119518489" green="0.35138896218467347" blue="0.62476789959191925" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="300" id="6lv-lF-cKu"/>
@@ -107,8 +127,13 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstItem="7Ev-bA-TBM" firstAttribute="width" secondItem="7Ev-bA-TBM" secondAttribute="height" multiplier="10:1" id="AV7-SN-b8d"/>
+                                </constraints>
                             </stackView>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="I1w-Xb-xRn" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="16" id="A1n-lF-Kw5"/>

--- a/EJSelectMenuExample/EJMenuItem.h
+++ b/EJSelectMenuExample/EJMenuItem.h
@@ -20,6 +20,7 @@
 @interface EJMenuItem : UIView
 
 @property (nonatomic,strong) NSString *title;
+@property (nonatomic,strong) UIImage *backgroundImage;
 @property (nonatomic,strong) UIColor *selectedStateColor;
 
 @property (nonatomic,assign) id<EJMenuItemDelegate> delegate;

--- a/EJSelectMenuExample/EJMenuItem.m
+++ b/EJSelectMenuExample/EJMenuItem.m
@@ -40,7 +40,11 @@
     [self setButtonTitle:self.title];
     button = [[UIButton alloc]initWithFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
     [button addTarget:self action:@selector(buttonPressed:) forControlEvents:UIControlEventTouchUpInside];
-    
+
+    if (self.backgroundImage) {
+        [self setBackgroundImage:self.backgroundImage];
+    }
+
     self.userInteractionEnabled = YES;
     [self addSubview:button];
 }
@@ -58,6 +62,15 @@
         [button setTitle:@"Button" forState:UIControlStateNormal];
     }
     
+}
+
+-(void)setBackgroundImage:(UIImage *)image{
+    if (image) {
+        [button setBackgroundImage:image forState:UIControlStateNormal];
+        [button setBackgroundColor:[UIColor blackColor]];
+    } else {
+        [button setBackgroundImage:image forState:UIControlStateNormal];
+    }
 }
 
 -(void)expandAnimation{

--- a/EJSelectMenuExample/EJSelectMenu.h
+++ b/EJSelectMenuExample/EJSelectMenu.h
@@ -33,6 +33,7 @@ typedef NS_OPTIONS(NSUInteger,AnimationStyle){
 @property (nonatomic,strong) UIColor *menuBackgroundColor;
 @property (nonatomic,strong) UIColor *selectedButtonColor;
 @property (nonatomic,strong) NSArray *buttonNames;
+@property (nonatomic,strong) NSArray *buttonImages;
 
 @property (nonatomic) enum AnimationStyle animationStyle;
 

--- a/EJSelectMenuExample/EJSelectMenu.m
+++ b/EJSelectMenuExample/EJSelectMenu.m
@@ -48,7 +48,7 @@
         self.item = [[EJMenuItem alloc]
                      initWithFrame:CGRectMake(1, 20 + (i * heightBasedOnNumberOfButtons) + i, self.view.bounds.size.width - 2, heightBasedOnNumberOfButtons)];
         self.item.title = self.buttonNames[i];
-
+        self.item.backgroundImage = self.buttonImages[i] ? self.buttonImages[i] : [UIImage imageNamed:@"default"];
         self.item.backgroundColor = [UIColor colorWithRed:88/255.0 green:115/255.0 blue:160/255.0 alpha:1.0];
         self.item.selectedStateColor = self.selectedButtonColor;
         self.item.tag = 100 + i;

--- a/EJSelectMenuExample/ViewController.m
+++ b/EJSelectMenuExample/ViewController.m
@@ -33,6 +33,16 @@
     [self presentViewController:pop animated:NO completion:nil];
 }
 
+- (IBAction)popUp3ButtonsWithImages:(UIButton *)sender {
+    NSArray *buttonNames = @[@"MERCURY",@"VENUS",@"MARS"];
+    NSArray *buttonImages = @[[UIImage imageNamed:@"mercury"],
+                              [UIImage imageNamed:@"venus"],
+                              [UIImage imageNamed:@"mars"]];
+    EJSelectMenu *pop = [[EJSelectMenu alloc]initWithButtons:buttonNames animationStyle:EJAnimationStyleWiden andDelegate:self];
+    pop.buttonImages = buttonImages;
+    [self presentViewController:pop animated:NO completion:nil];
+}
+
 - (IBAction)popUp4ButtonPressed:(UIButton *)sender {
     NSArray *buttonNames = @[@"COFFEE",@"DECAF",@"TEA",@"WATER"];
     EJSelectMenu *pop = [[EJSelectMenu alloc]initWithButtons:buttonNames animationStyle:EJAnimationStyleWiden andDelegate:self];


### PR DESCRIPTION
You have the option to use images instead of colors for the button background, implemented as follows:

``` objective-c
NSArray *buttonNames = @[@"Button One",@"Button Two",@"Button Three"];
NSArray *buttonImages = @[[UIImage imageNamed:@"image-one"], 
                          [UIImage imageNamed:@"image-two"],
                          [UIImage imageNamed:@"image-three"]];
EJSelectMenu *myMenu = [[EJSelectMenu alloc]initWithButtons:buttonNames animationStyle:EJAnimationStyleWiden andDelegate:self];
myMenu.buttonImages = buttonImages;
[self presentViewController:myMenu animated:NO completion:nil];
```

If the number of images is less than the number of button names, the default blue color will be used for the button background.
